### PR TITLE
Feature/etag+last modified

### DIFF
--- a/src/com/jonfreer/wedding/WeddingApplicationConfiguration.java
+++ b/src/com/jonfreer/wedding/WeddingApplicationConfiguration.java
@@ -19,6 +19,7 @@ public class WeddingApplicationConfiguration extends ResourceConfig {
             e.printStackTrace();
         }
 
+        //JAX-RS Components.
         this.register(GuestResource.class);
         this.register(new GeneralExceptionMapper());
         this.register(new NotFoundExceptionMapper());
@@ -30,6 +31,7 @@ public class WeddingApplicationConfiguration extends ResourceConfig {
         this.register(new IReservationRepositoryFactoryBinder());
         this.register(new IExceptionRepositoryFactoryBinder());
         this.register(new IDatabaseUnitOfWorkFactoryBinder());
+        this.register(new IResourceMetadataRepositoryFactoryBinder());
         this.register(new MapperBinder());
     }
 }

--- a/src/com/jonfreer/wedding/WeddingApplicationConfiguration.java
+++ b/src/com/jonfreer/wedding/WeddingApplicationConfiguration.java
@@ -32,6 +32,7 @@ public class WeddingApplicationConfiguration extends ResourceConfig {
         this.register(new IExceptionRepositoryFactoryBinder());
         this.register(new IDatabaseUnitOfWorkFactoryBinder());
         this.register(new IResourceMetadataRepositoryFactoryBinder());
+        this.register(new IResourceMetadataServiceBinder());
         this.register(new MapperBinder());
     }
 }

--- a/src/com/jonfreer/wedding/api/EntityTagGenerator.java
+++ b/src/com/jonfreer/wedding/api/EntityTagGenerator.java
@@ -1,0 +1,35 @@
+/**
+ * 
+ */
+package com.jonfreer.wedding.api;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+/**
+ * @author jonfreer
+ *
+ */
+public class EntityTagGenerator {
+	public static String generate(byte[] bytes, boolean urlEncoded){
+		MessageDigest digest;
+		try {
+			digest = MessageDigest.getInstance("MD5");
+			byte[] bytesMD5 = digest.digest(bytes);
+			String entityTagStringBase64Encoded = 
+					Base64.getEncoder().encodeToString(bytesMD5);
+			
+			if(urlEncoded){
+				return URLEncoder.encode(entityTagStringBase64Encoded, "UTF8");
+			}
+			
+			return entityTagStringBase64Encoded;
+		} catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+			e.printStackTrace();
+			throw new RuntimeException(e);
+		}		
+	}
+}

--- a/src/com/jonfreer/wedding/api/interfaces/resources/IGuestResource.java
+++ b/src/com/jonfreer/wedding/api/interfaces/resources/IGuestResource.java
@@ -4,8 +4,11 @@ import com.jonfreer.wedding.application.exceptions.ResourceNotFoundException;
 import com.jonfreer.wedding.servicemodel.Guest;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 /**
  * Defines the interface for resources that wish to interact
@@ -31,6 +34,8 @@ public interface IGuestResource {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     Response getGuests(
+    		@Context Request request,
+    		@Context UriInfo uriInfo,
             @QueryParam("givenName") String givenName,
             @QueryParam("surname") String surname,
             @QueryParam("inviteCode") String inviteCode);
@@ -46,7 +51,9 @@ public interface IGuestResource {
     @POST
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    Response createGuest(Guest desiredGuestState) throws ResourceNotFoundException;
+    Response createGuest(
+    		@Context UriInfo uriInfo, 
+    		Guest desiredGuestState) throws ResourceNotFoundException;
 
     /**
      * Retrieves the current state of the guest resources with the id provided.
@@ -59,7 +66,10 @@ public interface IGuestResource {
     @Path("{id : \\d+}")
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    Response getGuest(@PathParam("id") int id) throws ResourceNotFoundException;
+    Response getGuest(
+    		@Context Request request,
+    		@Context UriInfo uriInfo, 
+    		@PathParam("id") int id) throws ResourceNotFoundException;
 
     /**
      * Replaces the current state of the guest resource with the id provided.
@@ -74,7 +84,11 @@ public interface IGuestResource {
     @PUT
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    Response updateGuest(@PathParam("id") int id, Guest desiredGuestState) throws ResourceNotFoundException;
+    Response updateGuest(
+    		@Context Request request, 
+    		@Context UriInfo uriInfo, 
+    		@PathParam("id") int id, 
+    		Guest desiredGuestState) throws ResourceNotFoundException;
 
     /**
      * Deletes the guest resource with the id provided.
@@ -87,5 +101,7 @@ public interface IGuestResource {
      */
     @Path("{id : \\d+}")
     @DELETE
-    Response deleteGuest(@PathParam("id") int id) throws ResourceNotFoundException;
+    Response deleteGuest(
+    		@Context UriInfo uriInfo, 
+    		@PathParam("id") int id) throws ResourceNotFoundException;
 }

--- a/src/com/jonfreer/wedding/application/interfaces/services/IResourceMetadataService.java
+++ b/src/com/jonfreer/wedding/application/interfaces/services/IResourceMetadataService.java
@@ -1,0 +1,43 @@
+package com.jonfreer.wedding.application.interfaces.services;
+
+import com.jonfreer.wedding.servicemodel.metadata.ResourceMetadata;
+import org.jvnet.hk2.annotations.Contract;
+
+import java.net.URI;
+
+/**
+ * @author jonfreer
+ * @since 1/5/17
+ */
+@Contract
+public interface IResourceMetadataService {
+
+    /**
+     * Retrieves resource metadata for a resource identified by
+     * the provided URI.
+     * @param uri The URI of the resource to retrieve metadata for.
+     * @return The resource metadata for the resource identified by
+     * the provided URI.
+     */
+    ResourceMetadata getResourceMetadata(URI uri);
+
+    /**
+     * Creates a new representation of resource metadata with the
+     * provided state.
+     * @param resourceMetadata The desired state for the new resource metadata.
+     */
+    void insertResourceMetadata(ResourceMetadata resourceMetadata);
+
+    /**
+     * Replaces the state an existing representation of metadata about a resource
+     * with the provided state.
+     * @param resourceMetadata The desired state for the resource metadata.
+     */
+    void updateResourceMetaData(ResourceMetadata resourceMetadata);
+
+    /**
+     * Deletes the resource metadata for a resource.
+     * @param uri The URI of the resource to delete metadata for.
+     */
+    void deleteResourceMetaData(URI uri);
+}

--- a/src/com/jonfreer/wedding/application/services/GuestService.java
+++ b/src/com/jonfreer/wedding/application/services/GuestService.java
@@ -71,13 +71,13 @@ public class GuestService implements IGuestService {
 
         } catch (ResourceNotFoundException resourceNotFoundEx) {
             unitOfWork.Undo();
-            this.logException(resourceNotFoundEx);
+            //this.logException(resourceNotFoundEx);
             throw new com.jonfreer.wedding.application.exceptions.ResourceNotFoundException(
                     resourceNotFoundEx.getMessage(),
                     resourceNotFoundEx, resourceNotFoundEx.getResourceId());
         } catch (Exception ex) {
             unitOfWork.Undo();
-            this.logException(ex);
+            //this.logException(ex);
             throw new RuntimeException(ex);
         }
     }
@@ -206,7 +206,8 @@ public class GuestService implements IGuestService {
             return guestId;
         } catch (Exception ex) {
             unitOfWork.Undo();
-            this.logException(ex);
+            //this.logException(ex);
+            ex.printStackTrace();
             throw new RuntimeException(ex);
         }
     }
@@ -237,7 +238,13 @@ public class GuestService implements IGuestService {
 
             unitOfWork.Save();
 
-            return this.mapper.map(guests, ArrayList.class);
+            ArrayList<com.jonfreer.wedding.servicemodel.Guest> guestsServiceModel = 
+            		new ArrayList<com.jonfreer.wedding.servicemodel.Guest>();
+            for(com.jonfreer.wedding.domain.Guest guest : guests){
+            	guestsServiceModel.add(this.mapper.map(guest, com.jonfreer.wedding.servicemodel.Guest.class));
+            }
+            
+            return guestsServiceModel;
         } catch (Exception ex) {
             unitOfWork.Undo();
             this.logException(ex);

--- a/src/com/jonfreer/wedding/application/services/ResourceMetadataService.java
+++ b/src/com/jonfreer/wedding/application/services/ResourceMetadataService.java
@@ -1,0 +1,134 @@
+package com.jonfreer.wedding.application.services;
+
+import com.jonfreer.wedding.application.interfaces.services.IResourceMetadataService;
+import com.jonfreer.wedding.domain.interfaces.repositories.IResourceMetadataRepository;
+import com.jonfreer.wedding.domain.interfaces.unitofwork.IDatabaseUnitOfWork;
+import com.jonfreer.wedding.servicemodel.metadata.ResourceMetadata;
+import com.jonfreer.wedding.infrastructure.interfaces.factories.IDatabaseUnitOfWorkFactory;
+import com.jonfreer.wedding.infrastructure.interfaces.factories.IResourceMetadataRepositoryFactory;
+import org.dozer.Mapper;
+import org.jvnet.hk2.annotations.Service;
+
+import javax.inject.Inject;
+import java.net.URI;
+
+/**
+ * @author jonfreer
+ * @since 1/5/17
+ */
+@Service
+public class ResourceMetadataService implements IResourceMetadataService {
+
+    private IResourceMetadataRepositoryFactory resourceMetadataRepositoryFactory;
+    private IDatabaseUnitOfWorkFactory databaseUnitOfWorkFactory;
+    private Mapper mapper;
+
+    /**
+     *
+     * @param resourceMetadataRepositoryFactory
+     * @param databaseUnitOfWorkFactory
+     * @param mapper
+     */
+    @Inject
+    public ResourceMetadataService(
+        IResourceMetadataRepositoryFactory resourceMetadataRepositoryFactory,
+        IDatabaseUnitOfWorkFactory databaseUnitOfWorkFactory,
+        Mapper mapper){
+
+        this.resourceMetadataRepositoryFactory = resourceMetadataRepositoryFactory;
+        this.databaseUnitOfWorkFactory = databaseUnitOfWorkFactory;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Retrieves resource metadata for a resource identified by
+     * the provided URI.
+     *
+     * @param uri The URI of the resource to retrieve metadata for.
+     * @return The resource metadata for the resource identified by
+     * the provided URI.
+     */
+    @Override
+    public ResourceMetadata getResourceMetadata(URI uri) {
+        try{
+            IDatabaseUnitOfWork databaseUnitOfWork =
+                this.databaseUnitOfWorkFactory.create();
+            IResourceMetadataRepository resourceMetadataRepository =
+                this.resourceMetadataRepositoryFactory.create(databaseUnitOfWork);
+
+            com.jonfreer.wedding.domain.metadata.ResourceMetadata resourceMetadata =
+                resourceMetadataRepository.getResourceMetadata(uri);
+
+            return this.mapper.map(resourceMetadata, ResourceMetadata.class);
+        }catch(Exception exception){
+            exception.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * Creates a new representation of resource metadata with the
+     * provided state.
+     *
+     * @param resourceMetadata The desired state for the new resource metadata.
+     */
+    @Override
+    public void insertResourceMetadata(ResourceMetadata resourceMetadata) {
+        try{
+            IDatabaseUnitOfWork databaseUnitOfWork =
+                this.databaseUnitOfWorkFactory.create();
+            IResourceMetadataRepository resourceMetadataRepository =
+                this.resourceMetadataRepositoryFactory.create(databaseUnitOfWork);
+
+            com.jonfreer.wedding.domain.metadata.ResourceMetadata resourceMetadataDomain =
+                this.mapper.map(
+                    resourceMetadata, com.jonfreer.wedding.domain.metadata.ResourceMetadata.class);
+
+            resourceMetadataRepository.insertResourceMetadata(resourceMetadataDomain);
+        }catch(Exception exception){
+            exception.printStackTrace();
+        }
+    }
+
+    /**
+     * Replaces the state an existing representation of metadata about a resource
+     * with the provided state.
+     *
+     * @param resourceMetadata The desired state for the resource metadata.
+     */
+    @Override
+    public void updateResourceMetaData(ResourceMetadata resourceMetadata) {
+        try{
+            IDatabaseUnitOfWork databaseUnitOfWork =
+                this.databaseUnitOfWorkFactory.create();
+            IResourceMetadataRepository resourceMetadataRepository =
+                this.resourceMetadataRepositoryFactory.create(databaseUnitOfWork);
+
+            com.jonfreer.wedding.domain.metadata.ResourceMetadata resourceMetadataDomain =
+                this.mapper.map(
+                    resourceMetadata, com.jonfreer.wedding.domain.metadata.ResourceMetadata.class);
+
+            resourceMetadataRepository.updateResourceMetaData(resourceMetadataDomain);
+        }catch(Exception exception){
+            exception.printStackTrace();
+        }
+    }
+
+    /**
+     * Deletes the resource metadata for a resource.
+     *
+     * @param uri The URI of the resource to delete metadata for.
+     */
+    @Override
+    public void deleteResourceMetaData(URI uri) {
+        try{
+            IDatabaseUnitOfWork databaseUnitOfWork =
+                this.databaseUnitOfWorkFactory.create();
+            IResourceMetadataRepository resourceMetadataRepository =
+                this.resourceMetadataRepositoryFactory.create(databaseUnitOfWork);
+            resourceMetadataRepository.deleteResourceMetaData(uri);
+        }catch(Exception exception){
+            exception.printStackTrace();
+        }
+    }
+}

--- a/src/com/jonfreer/wedding/application/services/ResourceMetadataService.java
+++ b/src/com/jonfreer/wedding/application/services/ResourceMetadataService.java
@@ -50,18 +50,25 @@ public class ResourceMetadataService implements IResourceMetadataService {
      */
     @Override
     public ResourceMetadata getResourceMetadata(URI uri) {
-        try{
-            IDatabaseUnitOfWork databaseUnitOfWork =
+    	IDatabaseUnitOfWork databaseUnitOfWork =
                 this.databaseUnitOfWorkFactory.create();
+        try{
             IResourceMetadataRepository resourceMetadataRepository =
                 this.resourceMetadataRepositoryFactory.create(databaseUnitOfWork);
 
             com.jonfreer.wedding.domain.metadata.ResourceMetadata resourceMetadata =
                 resourceMetadataRepository.getResourceMetadata(uri);
 
+            databaseUnitOfWork.Save();
+            
+            if(resourceMetadata == null){
+            	return null;
+            }
+            
             return this.mapper.map(resourceMetadata, ResourceMetadata.class);
         }catch(Exception exception){
             exception.printStackTrace();
+            databaseUnitOfWork.Undo();
         }
         return null;
     }
@@ -74,19 +81,24 @@ public class ResourceMetadataService implements IResourceMetadataService {
      */
     @Override
     public void insertResourceMetadata(ResourceMetadata resourceMetadata) {
-        try{
-            IDatabaseUnitOfWork databaseUnitOfWork =
-                this.databaseUnitOfWorkFactory.create();
+    	IDatabaseUnitOfWork databaseUnitOfWork =
+                this.databaseUnitOfWorkFactory.create();	
+    	try{
+            
             IResourceMetadataRepository resourceMetadataRepository =
                 this.resourceMetadataRepositoryFactory.create(databaseUnitOfWork);
 
-            com.jonfreer.wedding.domain.metadata.ResourceMetadata resourceMetadataDomain =
+            com.jonfreer.wedding.domain.metadata.ResourceMetadata resourceMetadataDomain = 
+            		new com.jonfreer.wedding.domain.metadata.ResourceMetadata();
                 this.mapper.map(
-                    resourceMetadata, com.jonfreer.wedding.domain.metadata.ResourceMetadata.class);
+                    resourceMetadata, resourceMetadataDomain);
 
             resourceMetadataRepository.insertResourceMetadata(resourceMetadataDomain);
+            
+            databaseUnitOfWork.Save();
         }catch(Exception exception){
             exception.printStackTrace();
+            databaseUnitOfWork.Undo();
         }
     }
 
@@ -98,9 +110,10 @@ public class ResourceMetadataService implements IResourceMetadataService {
      */
     @Override
     public void updateResourceMetaData(ResourceMetadata resourceMetadata) {
-        try{
-            IDatabaseUnitOfWork databaseUnitOfWork =
-                this.databaseUnitOfWorkFactory.create();
+    	IDatabaseUnitOfWork databaseUnitOfWork =
+                this.databaseUnitOfWorkFactory.create(); 	
+    	try{
+            
             IResourceMetadataRepository resourceMetadataRepository =
                 this.resourceMetadataRepositoryFactory.create(databaseUnitOfWork);
 
@@ -109,8 +122,10 @@ public class ResourceMetadataService implements IResourceMetadataService {
                     resourceMetadata, com.jonfreer.wedding.domain.metadata.ResourceMetadata.class);
 
             resourceMetadataRepository.updateResourceMetaData(resourceMetadataDomain);
+            databaseUnitOfWork.Save();
         }catch(Exception exception){
             exception.printStackTrace();
+            databaseUnitOfWork.Undo();
         }
     }
 
@@ -120,15 +135,17 @@ public class ResourceMetadataService implements IResourceMetadataService {
      * @param uri The URI of the resource to delete metadata for.
      */
     @Override
-    public void deleteResourceMetaData(URI uri) {
-        try{
-            IDatabaseUnitOfWork databaseUnitOfWork =
+    public void deleteResourceMetaData(URI uri) {      
+    	IDatabaseUnitOfWork databaseUnitOfWork =
                 this.databaseUnitOfWorkFactory.create();
+    	try{         
             IResourceMetadataRepository resourceMetadataRepository =
                 this.resourceMetadataRepositoryFactory.create(databaseUnitOfWork);
             resourceMetadataRepository.deleteResourceMetaData(uri);
+            databaseUnitOfWork.Save();
         }catch(Exception exception){
             exception.printStackTrace();
+            databaseUnitOfWork.Undo();
         }
     }
 }

--- a/src/com/jonfreer/wedding/domain/Guest.java
+++ b/src/com/jonfreer/wedding/domain/Guest.java
@@ -191,7 +191,7 @@ public class Guest implements Cloneable {
      *
      * @return The identifier of the guest.
      */
-    public int getId() {
+    public Integer getId() {
         return this.id;
     }
 
@@ -200,7 +200,7 @@ public class Guest implements Cloneable {
      *
      * @param id The desired identifier of the guest.
      */
-    public void setId(int id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/com/jonfreer/wedding/domain/GuestSearchCriteria.java
+++ b/src/com/jonfreer/wedding/domain/GuestSearchCriteria.java
@@ -1,7 +1,5 @@
 package com.jonfreer.wedding.domain;
 
-import com.jonfreer.wedding.infrastructure.repositories.GuestRepository;
-
 /**
  * Represents criteria that is used when searching through
  * the Guest resources.

--- a/src/com/jonfreer/wedding/domain/interfaces/repositories/IResourceMetadataRepository.java
+++ b/src/com/jonfreer/wedding/domain/interfaces/repositories/IResourceMetadataRepository.java
@@ -1,0 +1,44 @@
+package com.jonfreer.wedding.domain.interfaces.repositories;
+
+import com.jonfreer.wedding.domain.metadata.ResourceMetadata;
+
+import java.net.URI;
+
+/**
+ * Defines the contract for all implementing types
+ * that wish to serve as a repository for ResourceMetadata
+ * instances.
+ * @author jonfreer
+ * @since 1/4/17
+ */
+public interface IResourceMetadataRepository {
+
+    /**
+     * Retrieves resource metadata for a resource identified by
+     * the provided URI.
+     * @param uri The URI of the resource to retrieve metadata for.
+     * @return The resource metadata for the resource identified by
+     * the provided URI.
+     */
+    ResourceMetadata getResourceMetadata(URI uri);
+
+    /**
+     * Creates a new representation of resource metadata with the
+     * provided state.
+     * @param resourceMetadata The desired state for the new resource metadata.
+     */
+    void insertResourceMetadata(ResourceMetadata resourceMetadata);
+
+    /**
+     * Replaces the state an existing representation of metadata about a resource
+     * with the provided state.
+     * @param resourceMetadata The desired state for the resource metadata.
+     */
+    void updateResourceMetaData(ResourceMetadata resourceMetadata);
+
+    /**
+     * Deletes the resource metadata for a resource.
+     * @param uri The URI of the resource to delete metadata for.
+     */
+    void deleteResourceMetaData(URI uri);
+}

--- a/src/com/jonfreer/wedding/domain/metadata/ResourceMetadata.java
+++ b/src/com/jonfreer/wedding/domain/metadata/ResourceMetadata.java
@@ -1,0 +1,125 @@
+package com.jonfreer.wedding.domain.metadata;
+
+import java.net.URI;
+import java.util.Date;
+
+/**
+ * Represents metadata about a single resource.
+ * @author jonfreer
+ * @since 1/4/17
+ */
+public class ResourceMetadata {
+
+    private URI uri;
+    private Date lastModified;
+    private String entityTag;
+
+    /**
+     * Constructs a ResourceMetadata instance, provided a URI,
+     * last modified date and time, and an entity tag (also referred to as an ETag).
+     * @param uri The URI of the resource.
+     * @param lastModified The date and time that the resource identified by the URI
+     *                     was modified.
+     * @param entityTag The entity tag of the resource identified by the URI.
+     */
+    public ResourceMetadata(URI uri, Date lastModified, String entityTag){
+
+        if(uri == null) {
+            throw new IllegalArgumentException("The constructor argument 'uri' cannot be null.");
+        }
+
+        if(lastModified == null){
+            throw new IllegalArgumentException("The constructor argument 'lastModified' cannot be null.");
+        }
+
+        if(entityTag == null){
+            throw new IllegalArgumentException("The constructor argument 'entityTag' cannot be null.");
+        }
+
+        this.uri = URI.create(uri.toString());
+        this.lastModified = (Date)lastModified.clone();
+        this.entityTag = entityTag;
+    }
+
+    /**
+     * Retrieves the URI identifying the resource.
+     * @return The URI identifying the resource.
+     */
+    public URI getUri(){
+        return URI.create(this.uri.toString());
+    }
+
+    /**
+     * Retrieves the date and time that the resource
+     * was last modified.
+     * @return The date and time that the resource was
+     * last modified.
+     */
+    public Date getLastModified(){
+        return (Date)this.lastModified.clone();
+    }
+
+    /**
+     * Retrieves the entity tag (also referred to as an ETag)
+     * for the resource.
+     * @return The entity tag for the resource.
+     */
+    public String getEntityTag(){
+        return this.entityTag;
+    }
+
+    /**
+     * Determines if a provided object is semantically
+     * equivalent to the calling ResourceMetadata instance.
+     * @param object An instance of Object to be compared with
+     *               the calling ResourceMetadata instance.
+     * @return true if the Object instance provided is an instance
+     * of ResourceMetadata and is semantically equivalent to the calling
+     * ResourceMetadata instance; false otherwise.
+     */
+    @Override
+    public boolean equals(Object object){
+        if(object == null || this.getClass() != object.getClass()){ return false; }
+
+        ResourceMetadata resourceMetadata = (ResourceMetadata)object;
+        if(
+            this.uri.equals(resourceMetadata.uri) &&
+            this.lastModified.equals(resourceMetadata.lastModified) &&
+            this.entityTag.equals(resourceMetadata.entityTag)
+        ){
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Generates a hashcode representative of the current state of the
+     * calling ResourceMetadata instance.
+     * @return The hashcode of the calling ResourceMetadata instance.
+     */
+    @Override
+    public int hashCode(){
+        int hashCode = 1;
+        final int prime = 17;
+
+        hashCode = hashCode * prime + this.uri.hashCode();
+        hashCode = hashCode * prime + this.lastModified.hashCode();
+        hashCode = hashCode * prime + this.entityTag.hashCode();
+
+        return hashCode;
+    }
+
+    /**
+     * Creates a string representation of the calling ResourceMetadata instance.
+     * @return A string representation of the calling ResourceMetadata instance.
+     */
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(this.getClass().getName() + "\n");
+        builder.append("URI\t\t\t\t-->" + this.uri.toString() + "\n");
+        builder.append("Last Modified\t\t-->" + this.lastModified.toString() + "\n");
+        builder.append("Entity Tag\t\t-->" + this.entityTag + "\n");
+        return builder.toString();
+    }
+}

--- a/src/com/jonfreer/wedding/domain/metadata/ResourceMetadata.java
+++ b/src/com/jonfreer/wedding/domain/metadata/ResourceMetadata.java
@@ -1,6 +1,5 @@
 package com.jonfreer.wedding.domain.metadata;
 
-import java.net.URI;
 import java.util.Date;
 
 /**
@@ -10,10 +9,19 @@ import java.util.Date;
  */
 public class ResourceMetadata {
 
-    private URI uri;
+    private String uri;
     private Date lastModified;
     private String entityTag;
 
+    /**
+     * Constructs an empty instance of ResourceMetadata.
+     */
+    public ResourceMetadata(){
+    	this.uri = null;
+    	this.lastModified = null;
+    	this.entityTag = null;
+    }
+    
     /**
      * Constructs a ResourceMetadata instance, provided a URI,
      * last modified date and time, and an entity tag (also referred to as an ETag).
@@ -22,7 +30,7 @@ public class ResourceMetadata {
      *                     was modified.
      * @param entityTag The entity tag of the resource identified by the URI.
      */
-    public ResourceMetadata(URI uri, Date lastModified, String entityTag){
+    public ResourceMetadata(String uri, Date lastModified, String entityTag){
 
         if(uri == null) {
             throw new IllegalArgumentException("The constructor argument 'uri' cannot be null.");
@@ -36,17 +44,44 @@ public class ResourceMetadata {
             throw new IllegalArgumentException("The constructor argument 'entityTag' cannot be null.");
         }
 
-        this.uri = URI.create(uri.toString());
+        this.uri = uri;
         this.lastModified = (Date)lastModified.clone();
         this.entityTag = entityTag;
     }
 
     /**
+     * Alters the URI that identifies the resource to
+     * the URI provided.
+     * @param uri The desired URI to identify the resource.
+     */
+    public void setUri(String uri) {
+		this.uri = uri;
+	}
+
+    /**
+     * Alters the date the time that indicates when the resource
+     * was last modified to the date and time provided.
+     * @param lastModified The desired date and time indicating
+     * when the resource was last modified.
+     */
+	public void setLastModified(Date lastModified) {
+		this.lastModified = lastModified;
+	}
+
+	/**
+	 * Alters the entity tag of the resource to the entity tag provided.
+	 * @param entityTag The desired entity tag for the resource.
+	 */
+	public void setEntityTag(String entityTag) {
+		this.entityTag = entityTag;
+	}
+
+	/**
      * Retrieves the URI identifying the resource.
      * @return The URI identifying the resource.
      */
-    public URI getUri(){
-        return URI.create(this.uri.toString());
+    public String getUri(){
+    	return uri;
     }
 
     /**
@@ -56,7 +91,7 @@ public class ResourceMetadata {
      * last modified.
      */
     public Date getLastModified(){
-        return (Date)this.lastModified.clone();
+        return this.lastModified == null ? null : (Date)this.lastModified.clone();
     }
 
     /**
@@ -83,9 +118,19 @@ public class ResourceMetadata {
 
         ResourceMetadata resourceMetadata = (ResourceMetadata)object;
         if(
-            this.uri.equals(resourceMetadata.uri) &&
-            this.lastModified.equals(resourceMetadata.lastModified) &&
-            this.entityTag.equals(resourceMetadata.entityTag)
+        		(
+        				(this.uri == null && resourceMetadata.uri == null) ||
+        				this.uri.equals(resourceMetadata.uri)
+				) &&
+        		(
+        				(this.lastModified == null && resourceMetadata.lastModified == null) ||
+        				this.lastModified.equals(resourceMetadata.lastModified)
+				) &&
+        		(
+        				(this.entityTag == null && resourceMetadata.entityTag == null) ||
+        				this.entityTag.equals(resourceMetadata.entityTag)
+				)
+            
         ){
             return true;
         }
@@ -102,10 +147,18 @@ public class ResourceMetadata {
         int hashCode = 1;
         final int prime = 17;
 
-        hashCode = hashCode * prime + this.uri.hashCode();
-        hashCode = hashCode * prime + this.lastModified.hashCode();
-        hashCode = hashCode * prime + this.entityTag.hashCode();
-
+        if(this.uri != null){
+        	hashCode = hashCode * prime + this.uri.hashCode();
+        }
+        
+        if(this.lastModified != null){
+        	hashCode = hashCode * prime + this.lastModified.hashCode();
+        }
+        
+        if(this.entityTag != null){
+        	hashCode = hashCode * prime + this.entityTag.hashCode();
+        }
+        
         return hashCode;
     }
 
@@ -117,9 +170,9 @@ public class ResourceMetadata {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append(this.getClass().getName() + "\n");
-        builder.append("URI\t\t\t\t-->" + this.uri.toString() + "\n");
-        builder.append("Last Modified\t\t-->" + this.lastModified.toString() + "\n");
-        builder.append("Entity Tag\t\t-->" + this.entityTag + "\n");
+        builder.append("URI\t\t\t\t-->" + this.uri == null ? "null" : this.uri.toString() + "\n");
+        builder.append("Last Modified\t\t-->" + this.lastModified == null ? "null" : this.lastModified.toString() + "\n");
+        builder.append("Entity Tag\t\t-->" + this.entityTag == null ? "null" : this.entityTag + "\n");
         return builder.toString();
     }
 }

--- a/src/com/jonfreer/wedding/hk2/IResourceMetadataRepositoryFactoryBinder.java
+++ b/src/com/jonfreer/wedding/hk2/IResourceMetadataRepositoryFactoryBinder.java
@@ -1,0 +1,17 @@
+package com.jonfreer.wedding.hk2;
+
+import com.jonfreer.wedding.infrastructure.factories.ResourceMetadataRepositoryFactory;
+import com.jonfreer.wedding.infrastructure.interfaces.factories.IResourceMetadataRepositoryFactory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+/**
+ * @author jonfreer
+ * @since 1/5/17
+ */
+public class IResourceMetadataRepositoryFactoryBinder extends AbstractBinder{
+
+    @Override
+    protected void configure() {
+        this.bind(ResourceMetadataRepositoryFactory.class).to(IResourceMetadataRepositoryFactory.class);
+    }
+}

--- a/src/com/jonfreer/wedding/hk2/IResourceMetadataServiceBinder.java
+++ b/src/com/jonfreer/wedding/hk2/IResourceMetadataServiceBinder.java
@@ -1,0 +1,22 @@
+/**
+ * 
+ */
+package com.jonfreer.wedding.hk2;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import com.jonfreer.wedding.application.interfaces.services.IResourceMetadataService;
+import com.jonfreer.wedding.application.services.ResourceMetadataService;
+
+/**
+ * @author jonfreer
+ *
+ */
+public class IResourceMetadataServiceBinder extends AbstractBinder {
+
+	@Override
+	protected void configure() {
+		this.bind(ResourceMetadataService.class).to(IResourceMetadataService.class);
+	}
+
+}

--- a/src/com/jonfreer/wedding/infrastructure/factories/ResourceMetadataRepositoryFactory.java
+++ b/src/com/jonfreer/wedding/infrastructure/factories/ResourceMetadataRepositoryFactory.java
@@ -1,0 +1,25 @@
+package com.jonfreer.wedding.infrastructure.factories;
+
+import com.jonfreer.wedding.domain.interfaces.repositories.IResourceMetadataRepository;
+import com.jonfreer.wedding.domain.interfaces.unitofwork.IDatabaseUnitOfWork;
+import com.jonfreer.wedding.infrastructure.interfaces.factories.IResourceMetadataRepositoryFactory;
+import com.jonfreer.wedding.infrastructure.repositories.ResourceMetadataRepository;
+
+/**
+ * @author jonfreer
+ * @since 1/5/17
+ */
+public class ResourceMetadataRepositoryFactory implements IResourceMetadataRepositoryFactory {
+
+    /**
+     * Creates an instance of a class that implements the IResourceMetadataRepository interface.
+     *
+     * @param unitOfWork The instance of IDatabaseUnitOfWork needed to create a new instance
+     *                   of a class implementing the IResourceMetadataRepository interface.
+     * @return The instance of a class that implements the IResourceMetadataRepository interface.
+     */
+    @Override
+    public IResourceMetadataRepository create(IDatabaseUnitOfWork unitOfWork) {
+        return new ResourceMetadataRepository(unitOfWork);
+    }
+}

--- a/src/com/jonfreer/wedding/infrastructure/interfaces/factories/IResourceMetadataRepositoryFactory.java
+++ b/src/com/jonfreer/wedding/infrastructure/interfaces/factories/IResourceMetadataRepositoryFactory.java
@@ -1,0 +1,22 @@
+package com.jonfreer.wedding.infrastructure.interfaces.factories;
+
+import com.jonfreer.wedding.domain.interfaces.repositories.IResourceMetadataRepository;
+import com.jonfreer.wedding.domain.interfaces.unitofwork.IDatabaseUnitOfWork;
+
+/**
+ * Represents the contract that is to be implemented by any class that
+ * wishes to serve as a factory for instances implementing IResourceMetadataRepository.
+ * @author jonfreer
+ * @since 1/5/17
+ */
+public interface IResourceMetadataRepositoryFactory {
+
+    /**
+     * Creates an instance of a class that implements the IResourceMetadataRepository interface.
+     *
+     * @param unitOfWork The instance of IDatabaseUnitOfWork needed to create a new instance
+     *                   of a class implementing the IResourceMetadataRepository interface.
+     * @return The instance of a class that implements the IResourceMetadataRepository interface.
+     */
+    IResourceMetadataRepository create(IDatabaseUnitOfWork unitOfWork);
+}

--- a/src/com/jonfreer/wedding/infrastructure/repositories/ReservationRepository.java
+++ b/src/com/jonfreer/wedding/infrastructure/repositories/ReservationRepository.java
@@ -1,6 +1,13 @@
 package com.jonfreer.wedding.infrastructure.repositories;
 
-import java.sql.*;
+import java.sql.Timestamp;
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import java.util.Calendar;
+import java.util.TimeZone;
 
 import com.jonfreer.wedding.domain.Reservation;
 import com.jonfreer.wedding.domain.interfaces.repositories.IReservationRepository;
@@ -59,7 +66,12 @@ public class ReservationRepository extends DatabaseRepository implements IReserv
             if (result.next()) {
                 reservation = new Reservation();
                 reservation.setId(result.getInt("RESERVATION_ID"));
-                reservation.setSubmittedDateTime(result.getDate("DATETIME_SUBMITTED"));
+                reservation.setSubmittedDateTime(
+                		result.getTimestamp(
+                				"DATETIME_SUBMITTED", 
+                				Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        				)
+        		);
                 reservation.setIsAttending(result.getBoolean("IS_ATTENDING"));
             }
 
@@ -105,7 +117,11 @@ public class ReservationRepository extends DatabaseRepository implements IReserv
             cStatement =
                 this.getUnitOfWork().createCallableStatement("{CALL UpdateReservation(?, ?, ?)}");
             cStatement.setInt(1, desiredReservationState.getId());
-            cStatement.setDate(2, new java.sql.Date(desiredReservationState.getSubmittedDateTime().getTime()));
+            cStatement.setTimestamp(
+            		2, 
+            		new Timestamp(desiredReservationState.getSubmittedDateTime().getTime()), 
+            		Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+    		);
             cStatement.setBoolean(3, desiredReservationState.getIsAttending());
 
             int numOfRecords = cStatement.executeUpdate();

--- a/src/com/jonfreer/wedding/infrastructure/repositories/ResourceMetadataRepository.java
+++ b/src/com/jonfreer/wedding/infrastructure/repositories/ResourceMetadataRepository.java
@@ -1,0 +1,161 @@
+package com.jonfreer.wedding.infrastructure.repositories;
+
+import com.jonfreer.wedding.domain.interfaces.repositories.IResourceMetadataRepository;
+import com.jonfreer.wedding.domain.interfaces.unitofwork.IDatabaseUnitOfWork;
+import com.jonfreer.wedding.domain.metadata.ResourceMetadata;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.CallableStatement;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author jonfreer
+ * @since 1/4/17
+ */
+public class ResourceMetadataRepository extends DatabaseRepository implements IResourceMetadataRepository {
+
+    /**
+     * Constructs a repository of ResourceMetadata instances.
+     * @param unitOfWork An instance of a class that implements the
+     *                   IDatabaseUnitOfWork interface. All methods invoked
+     *                   on the ResourceMetadataRepository instance being created will
+     *                   utilize this unit of work.
+     */
+    public ResourceMetadataRepository(IDatabaseUnitOfWork unitOfWork){
+        super(unitOfWork);
+    }
+
+    /**
+     * Retrieves resource metadata for a resource identified by
+     * the provided URI.
+     *
+     * @param uri The URI of the resource to retrieve metadata for.
+     * @return The resource metadata for the resource identified by
+     * the provided URI.
+     */
+    @Override
+    public ResourceMetadata getResourceMetadata(URI uri) {
+        CallableStatement cStatement =
+            this.getUnitOfWork().createCallableStatement("{ CALL GetResourceMetadata(?) }");
+        ResultSet results = null;
+        try {
+            cStatement.setString(1, uri.toString());
+            results = cStatement.executeQuery();
+            if(results.next()){
+                ResourceMetadata resourceMetadata;
+                resourceMetadata = new ResourceMetadata(
+                        new URI(results.getString(1)),
+                        results.getDate(2),
+                        results.getString(3)
+                );
+                return resourceMetadata;
+            }
+        } catch (SQLException sqlException) {
+            sqlException.printStackTrace();
+
+        } catch (URISyntaxException uriSyntaxException) {
+            uriSyntaxException.printStackTrace();
+        }
+        finally{
+            try{
+                if(cStatement != null && !cStatement.isClosed()){
+                    cStatement.close();
+                }
+                if(results != null && !results.isClosed()){
+                    results.close();
+                }
+            }
+            catch(SQLException anotherSqlException){
+                anotherSqlException.printStackTrace();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates a new representation of resource metadata with the
+     * provided state.
+     *
+     * @param resourceMetadata The desired state for the new resource metadata.
+     */
+    @Override
+    public void insertResourceMetadata(ResourceMetadata resourceMetadata) {
+        CallableStatement cStatement =
+            this.getUnitOfWork().createCallableStatement("{ CALL CreateResourceMetadata(?, ?, ?) }");
+        try {
+            cStatement.setString(1, resourceMetadata.getUri().toString());
+            cStatement.setDate(2, new Date(resourceMetadata.getLastModified().getTime()));
+            cStatement.setString(3, resourceMetadata.getEntityTag());
+            cStatement.executeUpdate();
+        } catch (SQLException sqlException) {
+            sqlException.printStackTrace();
+        } finally {
+            try{
+                if(cStatement != null && !cStatement.isClosed()){
+                    cStatement.close();
+                }
+            }
+            catch(SQLException anotherSqlException){
+                anotherSqlException.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Replaces the state an existing representation of metadata about a resource
+     * with the provided state.
+     *
+     * @param resourceMetadata The desired state for the resource metadata.
+     */
+    @Override
+    public void updateResourceMetaData(ResourceMetadata resourceMetadata) {
+        CallableStatement cStatement =
+            this.getUnitOfWork().createCallableStatement("{ CALL UpdateResourceData(?, ?, ?) }");
+        try {
+            cStatement.setString(1, resourceMetadata.getUri().toString());
+            cStatement.setDate(2, new Date(resourceMetadata.getLastModified().getTime()));
+            cStatement.setString(3, resourceMetadata.getEntityTag());
+            cStatement.executeUpdate();
+        } catch (SQLException sqlException) {
+            sqlException.printStackTrace();
+        } finally {
+            try{
+                if(cStatement != null && !cStatement.isClosed()){
+                    cStatement.close();
+                }
+            }
+            catch(SQLException anotherSqlException){
+                anotherSqlException.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Deletes the resource metadata for a resource.
+     *
+     * @param uri The URI of the resource to delete metadata for.
+     */
+    @Override
+    public void deleteResourceMetaData(URI uri) {
+        CallableStatement cStatement =
+            this.getUnitOfWork().createCallableStatement("{ CALL DeleteResourceMetadata(?) }");
+        try{
+
+            cStatement.setString(1, uri.toString());
+            cStatement.executeUpdate();
+        }catch (SQLException sqlException) {
+            sqlException.printStackTrace();
+        } finally {
+            try{
+                if(cStatement != null && !cStatement.isClosed()){
+                    cStatement.close();
+                }
+            }catch(SQLException anotherSqlException) {
+                anotherSqlException.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/com/jonfreer/wedding/infrastructure/repositories/ResourceMetadataRepository.java
+++ b/src/com/jonfreer/wedding/infrastructure/repositories/ResourceMetadataRepository.java
@@ -5,11 +5,12 @@ import com.jonfreer.wedding.domain.interfaces.unitofwork.IDatabaseUnitOfWork;
 import com.jonfreer.wedding.domain.metadata.ResourceMetadata;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.sql.CallableStatement;
-import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.TimeZone;
 
 /**
  * @author jonfreer
@@ -47,8 +48,8 @@ public class ResourceMetadataRepository extends DatabaseRepository implements IR
             if(results.next()){
                 ResourceMetadata resourceMetadata;
                 resourceMetadata = new ResourceMetadata(
-                        new URI(results.getString(1)),
-                        results.getDate(2),
+                        results.getString(1),
+                        results.getTimestamp(2, Calendar.getInstance(TimeZone.getTimeZone("UTC"))),
                         results.getString(3)
                 );
                 return resourceMetadata;
@@ -56,8 +57,6 @@ public class ResourceMetadataRepository extends DatabaseRepository implements IR
         } catch (SQLException sqlException) {
             sqlException.printStackTrace();
 
-        } catch (URISyntaxException uriSyntaxException) {
-            uriSyntaxException.printStackTrace();
         }
         finally{
             try{
@@ -87,7 +86,11 @@ public class ResourceMetadataRepository extends DatabaseRepository implements IR
             this.getUnitOfWork().createCallableStatement("{ CALL CreateResourceMetadata(?, ?, ?) }");
         try {
             cStatement.setString(1, resourceMetadata.getUri().toString());
-            cStatement.setDate(2, new Date(resourceMetadata.getLastModified().getTime()));
+            cStatement.setTimestamp(
+            		2, 
+            		new Timestamp(resourceMetadata.getLastModified().getTime()), 
+            		Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+    		);
             cStatement.setString(3, resourceMetadata.getEntityTag());
             cStatement.executeUpdate();
         } catch (SQLException sqlException) {
@@ -113,10 +116,14 @@ public class ResourceMetadataRepository extends DatabaseRepository implements IR
     @Override
     public void updateResourceMetaData(ResourceMetadata resourceMetadata) {
         CallableStatement cStatement =
-            this.getUnitOfWork().createCallableStatement("{ CALL UpdateResourceData(?, ?, ?) }");
+            this.getUnitOfWork().createCallableStatement("{ CALL UpdateResourceMetadata(?, ?, ?) }");
         try {
             cStatement.setString(1, resourceMetadata.getUri().toString());
-            cStatement.setDate(2, new Date(resourceMetadata.getLastModified().getTime()));
+            cStatement.setTimestamp(
+            		2, 
+            		new Timestamp(resourceMetadata.getLastModified().getTime()), 
+            		Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+    		);
             cStatement.setString(3, resourceMetadata.getEntityTag());
             cStatement.executeUpdate();
         } catch (SQLException sqlException) {

--- a/src/com/jonfreer/wedding/servicemodel/Guest.java
+++ b/src/com/jonfreer/wedding/servicemodel/Guest.java
@@ -191,7 +191,7 @@ public class Guest implements Cloneable {
      *
      * @return The identifier of the guest.
      */
-    public int getId() {
+    public Integer getId() {
         return this.id;
     }
 
@@ -200,7 +200,7 @@ public class Guest implements Cloneable {
      *
      * @param id The desired identifier of the guest.
      */
-    public void setId(int id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/com/jonfreer/wedding/servicemodel/metadata/ResourceMetadata.java
+++ b/src/com/jonfreer/wedding/servicemodel/metadata/ResourceMetadata.java
@@ -1,6 +1,5 @@
 package com.jonfreer.wedding.servicemodel.metadata;
 
-import java.net.URI;
 import java.util.Date;
 
 /**
@@ -10,10 +9,19 @@ import java.util.Date;
  */
 public class ResourceMetadata {
 
-    private URI uri;
+	private String uri;
     private Date lastModified;
     private String entityTag;
 
+    /**
+     * Constructs an empty instance of ResourceMetadata.
+     */
+    public ResourceMetadata(){
+    	this.uri = null;
+    	this.lastModified = null;
+    	this.entityTag = null;
+    }
+    
     /**
      * Constructs a ResourceMetadata instance, provided a URI,
      * last modified date and time, and an entity tag (also referred to as an ETag).
@@ -22,7 +30,7 @@ public class ResourceMetadata {
      *                     was modified.
      * @param entityTag The entity tag of the resource identified by the URI.
      */
-    public ResourceMetadata(URI uri, Date lastModified, String entityTag){
+    public ResourceMetadata(String uri, Date lastModified, String entityTag){
 
         if(uri == null) {
             throw new IllegalArgumentException("The constructor argument 'uri' cannot be null.");
@@ -36,17 +44,44 @@ public class ResourceMetadata {
             throw new IllegalArgumentException("The constructor argument 'entityTag' cannot be null.");
         }
 
-        this.uri = URI.create(uri.toString());
+        this.uri = uri;
         this.lastModified = (Date)lastModified.clone();
         this.entityTag = entityTag;
     }
 
     /**
+     * Alters the URI that identifies the resource to
+     * the URI provided.
+     * @param uri The desired URI to identify the resource.
+     */
+    public void setUri(String uri) {
+		this.uri = uri;
+	}
+
+    /**
+     * Alters the date the time that indicates when the resource
+     * was last modified to the date and time provided.
+     * @param lastModified The desired date and time indicating
+     * when the resource was last modified.
+     */
+	public void setLastModified(Date lastModified) {
+		this.lastModified = lastModified;
+	}
+
+	/**
+	 * Alters the entity tag of the resource to the entity tag provided.
+	 * @param entityTag The desired entity tag for the resource.
+	 */
+	public void setEntityTag(String entityTag) {
+		this.entityTag = entityTag;
+	}
+
+	/**
      * Retrieves the URI identifying the resource.
      * @return The URI identifying the resource.
      */
-    public URI getUri(){
-        return URI.create(this.uri.toString());
+    public String getUri(){
+    	return uri;
     }
 
     /**
@@ -56,7 +91,7 @@ public class ResourceMetadata {
      * last modified.
      */
     public Date getLastModified(){
-        return (Date)this.lastModified.clone();
+        return this.lastModified == null ? null : (Date)this.lastModified.clone();
     }
 
     /**
@@ -83,9 +118,19 @@ public class ResourceMetadata {
 
         ResourceMetadata resourceMetadata = (ResourceMetadata)object;
         if(
-            this.uri.equals(resourceMetadata.uri) &&
-                    this.lastModified.equals(resourceMetadata.lastModified) &&
-                    this.entityTag.equals(resourceMetadata.entityTag)
+        		(
+        				(this.uri == null && resourceMetadata.uri == null) ||
+        				this.uri.equals(resourceMetadata.uri)
+				) &&
+        		(
+        				(this.lastModified == null && resourceMetadata.lastModified == null) ||
+        				this.lastModified.equals(resourceMetadata.lastModified)
+				) &&
+        		(
+        				(this.entityTag == null && resourceMetadata.entityTag == null) ||
+        				this.entityTag.equals(resourceMetadata.entityTag)
+				)
+            
         ){
             return true;
         }
@@ -102,10 +147,18 @@ public class ResourceMetadata {
         int hashCode = 1;
         final int prime = 17;
 
-        hashCode = hashCode * prime + this.uri.hashCode();
-        hashCode = hashCode * prime + this.lastModified.hashCode();
-        hashCode = hashCode * prime + this.entityTag.hashCode();
-
+        if(this.uri != null){
+        	hashCode = hashCode * prime + this.uri.hashCode();
+        }
+        
+        if(this.lastModified != null){
+        	hashCode = hashCode * prime + this.lastModified.hashCode();
+        }
+        
+        if(this.entityTag != null){
+        	hashCode = hashCode * prime + this.entityTag.hashCode();
+        }
+        
         return hashCode;
     }
 
@@ -117,9 +170,9 @@ public class ResourceMetadata {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append(this.getClass().getName() + "\n");
-        builder.append("URI\t\t\t\t-->" + this.uri.toString() + "\n");
-        builder.append("Last Modified\t\t-->" + this.lastModified.toString() + "\n");
-        builder.append("Entity Tag\t\t-->" + this.entityTag + "\n");
+        builder.append("URI\t\t\t\t-->" + this.uri == null ? "null" : this.uri.toString() + "\n");
+        builder.append("Last Modified\t\t-->" + this.lastModified == null ? "null" : this.lastModified.toString() + "\n");
+        builder.append("Entity Tag\t\t-->" + this.entityTag == null ? "null" : this.entityTag + "\n");
         return builder.toString();
     }
 }

--- a/src/com/jonfreer/wedding/servicemodel/metadata/ResourceMetadata.java
+++ b/src/com/jonfreer/wedding/servicemodel/metadata/ResourceMetadata.java
@@ -1,0 +1,125 @@
+package com.jonfreer.wedding.servicemodel.metadata;
+
+import java.net.URI;
+import java.util.Date;
+
+/**
+ * Represents metadata about a single resource.
+ * @author jonfreer
+ * @since 1/4/17
+ */
+public class ResourceMetadata {
+
+    private URI uri;
+    private Date lastModified;
+    private String entityTag;
+
+    /**
+     * Constructs a ResourceMetadata instance, provided a URI,
+     * last modified date and time, and an entity tag (also referred to as an ETag).
+     * @param uri The URI of the resource.
+     * @param lastModified The date and time that the resource identified by the URI
+     *                     was modified.
+     * @param entityTag The entity tag of the resource identified by the URI.
+     */
+    public ResourceMetadata(URI uri, Date lastModified, String entityTag){
+
+        if(uri == null) {
+            throw new IllegalArgumentException("The constructor argument 'uri' cannot be null.");
+        }
+
+        if(lastModified == null){
+            throw new IllegalArgumentException("The constructor argument 'lastModified' cannot be null.");
+        }
+
+        if(entityTag == null){
+            throw new IllegalArgumentException("The constructor argument 'entityTag' cannot be null.");
+        }
+
+        this.uri = URI.create(uri.toString());
+        this.lastModified = (Date)lastModified.clone();
+        this.entityTag = entityTag;
+    }
+
+    /**
+     * Retrieves the URI identifying the resource.
+     * @return The URI identifying the resource.
+     */
+    public URI getUri(){
+        return URI.create(this.uri.toString());
+    }
+
+    /**
+     * Retrieves the date and time that the resource
+     * was last modified.
+     * @return The date and time that the resource was
+     * last modified.
+     */
+    public Date getLastModified(){
+        return (Date)this.lastModified.clone();
+    }
+
+    /**
+     * Retrieves the entity tag (also referred to as an ETag)
+     * for the resource.
+     * @return The entity tag for the resource.
+     */
+    public String getEntityTag(){
+        return this.entityTag;
+    }
+
+    /**
+     * Determines if a provided object is semantically
+     * equivalent to the calling ResourceMetadata instance.
+     * @param object An instance of Object to be compared with
+     *               the calling ResourceMetadata instance.
+     * @return true if the Object instance provided is an instance
+     * of ResourceMetadata and is semantically equivalent to the calling
+     * ResourceMetadata instance; false otherwise.
+     */
+    @Override
+    public boolean equals(Object object){
+        if(object == null || this.getClass() != object.getClass()){ return false; }
+
+        ResourceMetadata resourceMetadata = (ResourceMetadata)object;
+        if(
+            this.uri.equals(resourceMetadata.uri) &&
+                    this.lastModified.equals(resourceMetadata.lastModified) &&
+                    this.entityTag.equals(resourceMetadata.entityTag)
+        ){
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Generates a hashcode representative of the current state of the
+     * calling ResourceMetadata instance.
+     * @return The hashcode of the calling ResourceMetadata instance.
+     */
+    @Override
+    public int hashCode(){
+        int hashCode = 1;
+        final int prime = 17;
+
+        hashCode = hashCode * prime + this.uri.hashCode();
+        hashCode = hashCode * prime + this.lastModified.hashCode();
+        hashCode = hashCode * prime + this.entityTag.hashCode();
+
+        return hashCode;
+    }
+
+    /**
+     * Creates a string representation of the calling ResourceMetadata instance.
+     * @return A string representation of the calling ResourceMetadata instance.
+     */
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(this.getClass().getName() + "\n");
+        builder.append("URI\t\t\t\t-->" + this.uri.toString() + "\n");
+        builder.append("Last Modified\t\t-->" + this.lastModified.toString() + "\n");
+        builder.append("Entity Tag\t\t-->" + this.entityTag + "\n");
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
## Release Notes

- Adds complete support for `ETag`, `Last-Modified`, and `Cache-Control` headers.
- Introduces `ResourceMetadata` which represents all of the metadata that can be stored for a resource, including entity tags and timestamps.
- Adds code to retrieve and store `java.sql.Timestamp` in UTC format.
  - In order to get the `java.sql.Timestamp` values to store in UTC format, I had to deal with a workaround for a known bug in the `MySQL` JDBC driver.
    - http://stackoverflow.com/questions/309203/how-to-store-a-java-util-date-into-a-mysql-timestamp-field-in-the-utc-gmt-timezo
- Makes used of boxed-equivalents to primitive types for service models to more accurately reflect the possible received input from the client.