### PR TITLE
Fixes bug where reservation could not be created for PUT /api/wedding /guests/{id}/.

### DIFF
--- a/src/com/jonfreer/wedding/application/services/GuestService.java
+++ b/src/com/jonfreer/wedding/application/services/GuestService.java
@@ -123,7 +123,8 @@ public class GuestService implements IGuestService {
                 }
             } else {
                 if (guestCurrentState.getReservation() == null) {
-                    reservationRepository.insertReservation(guestDomain.getReservation());
+                    int id = reservationRepository.insertReservation(guestDomain.getReservation());
+                    guestDomain.getReservation().setId(id);
                 } else {
                     reservationRepository.updateReservation(guestDomain.getReservation());
                 }


### PR DESCRIPTION
## Release Notes

- A `NullPointerException` was being thrown for the `PUT /api/wedding/guests/{id}/` request.
  - If a `reservation` resource was being created for the `guest` resource being updated, a `NullPointerException` occurred because the `id` of the newly created reservation was not being associated to `Guest` instance being used to update the database.