### PR TITLE
Removes code that sets the Content-Type HTTP header for GET Request.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -30,7 +30,6 @@ eventModule.attach("nav-button", "click", function(){
 eventModule.attach("enter-code-button", "click", function(e){
 	e.preventDefault();
 	var headers = {};
-	headers["Content-Type"] = "application/json";
 	headers["Accept"] = "application/json";
 	
 	ajaxModule.get(


### PR DESCRIPTION
## Release Notes

- Removes a bug ( #42 ) where the `Content-Type` HTTP header was being sent in the `GET` request to `/api/wedding/guests/?inviteCode=<code>`.
- This was triggering a CORS preflight request to be made since the value of `Content-Type` was not one of the following:
  - `application/x-www-form-urlencoded`
  - `text/plain`
  - `multipart/form-data`