### PR TITLE
Creates several filters to break out conditional request logic.

### DIFF
--- a/src/com/jonfreer/wedding/WeddingApplicationConfiguration.java
+++ b/src/com/jonfreer/wedding/WeddingApplicationConfiguration.java
@@ -4,7 +4,17 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.jonfreer.wedding.api.resources.GuestResource;
 import com.jonfreer.wedding.api.exceptionmappers.GeneralExceptionMapper;
 import com.jonfreer.wedding.api.exceptionmappers.NotFoundExceptionMapper;
-import com.jonfreer.wedding.hk2.*;
+import com.jonfreer.wedding.api.filters.CacheControlFilter;
+import com.jonfreer.wedding.api.filters.ConditionalGetFilter;
+import com.jonfreer.wedding.api.filters.ConditionalPutFilter;
+import com.jonfreer.wedding.hk2.IGuestServiceBinder;
+import com.jonfreer.wedding.hk2.IDatabaseUnitOfWorkFactoryBinder;
+import com.jonfreer.wedding.hk2.IExceptionRepositoryFactoryBinder;
+import com.jonfreer.wedding.hk2.IReservationRepositoryFactoryBinder;
+import com.jonfreer.wedding.hk2.IGuestRepositoryFactoryBinder;
+import com.jonfreer.wedding.hk2.IResourceMetadataRepositoryFactoryBinder;
+import com.jonfreer.wedding.hk2.IResourceMetadataServiceBinder;
+import com.jonfreer.wedding.hk2.MapperBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 
 /**
@@ -21,9 +31,12 @@ public class WeddingApplicationConfiguration extends ResourceConfig {
 
         //JAX-RS Components.
         this.register(GuestResource.class);
-        this.register(new GeneralExceptionMapper());
-        this.register(new NotFoundExceptionMapper());
-        this.register(new JacksonJsonProvider());
+        this.register(GeneralExceptionMapper.class);
+        this.register(NotFoundExceptionMapper.class);
+        this.register(JacksonJsonProvider.class);
+        this.register(CacheControlFilter.class);
+        this.register(ConditionalGetFilter.class);
+        this.register(ConditionalPutFilter.class);
 
         //HK2 Binders.
         this.register(new IGuestServiceBinder());

--- a/src/com/jonfreer/wedding/api/filters/CacheControlFilter.java
+++ b/src/com/jonfreer/wedding/api/filters/CacheControlFilter.java
@@ -1,0 +1,43 @@
+package com.jonfreer.wedding.api.filters;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class CacheControlFilter implements ContainerResponseFilter {
+
+	@Override
+	public void filter(
+		ContainerRequestContext requestContext, 
+		ContainerResponseContext responseContext) throws IOException {
+		
+		//do i really need this? there has got to be a way
+		//that response filters do not run when an exception occurs.
+		if(responseContext.getStatus() >= 400){ return; }
+		
+		Request request = requestContext.getRequest();
+		
+		if(request.getMethod().equalsIgnoreCase("GET")){
+			
+			UriInfo uriInfo = requestContext.getUriInfo();
+			
+			//for now, not providing caching abilities of search results.
+			if(uriInfo.getQueryParameters().isEmpty()){
+				
+				CacheControl cacheControl = new CacheControl();
+				cacheControl.setPrivate(true);
+				cacheControl.setMaxAge(300);
+				
+				responseContext.getHeaders().add("Cache-Control", cacheControl);
+			}
+		}
+	}
+
+}

--- a/src/com/jonfreer/wedding/api/filters/ConditionalGetFilter.java
+++ b/src/com/jonfreer/wedding/api/filters/ConditionalGetFilter.java
@@ -1,0 +1,55 @@
+package com.jonfreer.wedding.api.filters;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.ext.Provider;
+
+import com.jonfreer.wedding.application.interfaces.services.IResourceMetadataService;
+import com.jonfreer.wedding.servicemodel.metadata.ResourceMetadata;
+
+@Provider
+public class ConditionalGetFilter implements ContainerRequestFilter {
+
+	private IResourceMetadataService resourceMetadataService;
+	
+	@Inject
+	public ConditionalGetFilter(
+		IResourceMetadataService resourceMetadataService) {
+		
+		this.resourceMetadataService = resourceMetadataService;
+	}
+	
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		
+		Request request = requestContext.getRequest();
+		
+		if(request.getMethod().equalsIgnoreCase("GET")){
+			
+			ResourceMetadata resourceMetadata =
+				this.resourceMetadataService.getResourceMetadata(
+					requestContext.getUriInfo().getRequestUri());
+			
+			if(resourceMetadata != null){
+				ResponseBuilder responseBuilder = 
+					request.evaluatePreconditions(
+						resourceMetadata.getLastModified(), new EntityTag(resourceMetadata.getEntityTag()));
+				
+				if(responseBuilder != null){
+					responseBuilder.header("Last-Modified", resourceMetadata.getLastModified());
+					Response response = responseBuilder.build();
+					
+					requestContext.abortWith(response);
+				}
+			}	
+		}
+	}
+
+}

--- a/src/com/jonfreer/wedding/api/filters/ConditionalPutFilter.java
+++ b/src/com/jonfreer/wedding/api/filters/ConditionalPutFilter.java
@@ -1,0 +1,51 @@
+package com.jonfreer.wedding.api.filters;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+import com.jonfreer.wedding.application.interfaces.services.IResourceMetadataService;
+import com.jonfreer.wedding.servicemodel.metadata.ResourceMetadata;
+
+@Provider
+public class ConditionalPutFilter implements ContainerRequestFilter {
+
+	private IResourceMetadataService resourceMetadataService;
+	
+	@Inject
+	public ConditionalPutFilter(IResourceMetadataService resourceMetadataService){
+		this.resourceMetadataService = resourceMetadataService;
+	}
+	
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		
+		Request request = requestContext.getRequest();
+		UriInfo uriInfo = requestContext.getUriInfo();
+		
+		if(request.getMethod().equalsIgnoreCase("PUT")){
+			
+			ResourceMetadata resourceMetadata = 
+				this.resourceMetadataService.getResourceMetadata(uriInfo.getRequestUri());
+			
+			if(resourceMetadata != null){
+				
+				ResponseBuilder responseBuilder = 
+					request.evaluatePreconditions(
+						resourceMetadata.getLastModified(), 
+						new EntityTag(resourceMetadata.getEntityTag()));
+				
+				if(responseBuilder != null){
+					requestContext.abortWith(responseBuilder.build());
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Release Notes

- Creates two request filters `ConditionalGetFilter` and `ConditionalPutFilter` that are responsible for carrying out the logic of handling conditional requests for HTTP GET requests and HTTP PUT requests ( #32 ).
- Creates a single response filter `CacheControlFilter` that is responsible for setting the `Cache-Control` header in responses to HTTP GET requests.
